### PR TITLE
Add Idit Levine as a maintainer of the specification

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout
+* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout @ilevine


### PR DESCRIPTION
I would like to endorse [Idit Levine](https://github.com/ilevine) from Solo.io to be added as a specification maintainer. It was a miss on my part that she wasn't already included. 

Idit was one of the first launch partners of Service Mesh Interface and has been responsible for landing implementations in [SuperGloo](https://github.com/solo-io/supergloo), [Service Mesh Hub](https://github.com/solo-io/service-mesh-hub), building and maintaining SMI demos, and overall evangelism of SMI in the ecosystem. Her expertise and opinion in the service mesh ecosystem is extremely valuable.

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>