### PR TITLE
Add TCP/UDP routes and access control to spec

### DIFF
--- a/apis/traffic-access/traffic-access-WD.md
+++ b/apis/traffic-access/traffic-access-WD.md
@@ -94,8 +94,9 @@ This example selects all the pods which have the `service-a` `ServiceAccount`.
 Traffic destined on a path `/metrics` is allowed. The `matches` field is
 optional and if omitted, a rule is valid for all the matches in a traffic spec
 (a OR relationship).  It is possible for a service to expose multiple ports,
-the TCPRoute/UDPRoute `matches.ports` field allows the user to specify specifically which port traffic
-should be allowed on. The `matches.ports` is an optional element, if not specified, traffic
+the TCPRoute/UDPRoute `matches.ports` field allows the user to specify
+specifically which port traffic should be allowed on.
+The `matches.ports` is an optional element, if not specified, traffic
 will be allowed to all ports on the destination service.
 
 Allowing destination traffic should only be possible with permission of the
@@ -195,8 +196,8 @@ The previous example would allow the following HTTP traffic:
 
 ## Example implementation for L4
 
-The following implementation how to define TrafficTargets for allowing TCP and UDP
-traffic to specific ports.
+The following implementation shows how to define TrafficTargets for
+allowing TCP and UDP traffic to specific ports.
 
 ```yaml
 kind: TCPRoute
@@ -237,8 +238,8 @@ spec:
     namespace: default
 ```
 
-Note that the above configuration will allow TCP and UDP traffic to both `8301` and `8302` ports,
-but will block UDP traffic to `8300`.
+Note that the above configuration will allow TCP and UDP traffic to
+both `8301` and `8302` ports, but will block UDP traffic to `8300`.
 
 ## Tradeoffs
 

--- a/apis/traffic-specs/traffic-specs-WD.md
+++ b/apis/traffic-specs/traffic-specs-WD.md
@@ -137,14 +137,54 @@ to any path and all HTTP methods.
 
 ### TCPRoute
 
-This resource is used to describe L4 TCP traffic. It is a simple route which configures
-an application to receive raw non protocol specific traffic.
+This resource is used to describe L4 TCP traffic for a list of ports.
 
 ```yaml
 kind: TCPRoute
 metadata:
-  name: tcp-route
-spec: {}
+  name: the-routes
+spec:
+  matches:
+    ports:
+    - 3306
+    - 6446
+```
+
+When matching ports are not specified, the TCP route will match all the ports of a Kubernetes service:
+
+```yaml
+kind: TCPRoute
+metadata:
+  name: the-routes
+spec:
+  matches:
+    ports: []
+```
+
+### UDPRoute
+
+This resource is used to describe L4 UDP traffic for a list of ports.
+
+```yaml
+kind: UDPRoute
+metadata:
+  name: the-routes
+spec:
+  matches:
+    ports:
+    - 989
+    - 990
+```
+
+When matching ports are not specified, the UDP route will match all the ports of a Kubernetes service:
+
+```yaml
+kind: UDPRoute
+metadata:
+  name: the-routes
+spec:
+  matches:
+    ports: []
 ```
 
 ## Automatic Generation

--- a/apis/traffic-specs/traffic-specs-WD.md
+++ b/apis/traffic-specs/traffic-specs-WD.md
@@ -150,7 +150,8 @@ spec:
     - 6446
 ```
 
-When matching ports are not specified, the TCP route will match all the ports of a Kubernetes service:
+When matching ports are not specified,
+the TCP route will match all the ports of a Kubernetes service:
 
 ```yaml
 kind: TCPRoute
@@ -176,7 +177,8 @@ spec:
     - 990
 ```
 
-When matching ports are not specified, the UDP route will match all the ports of a Kubernetes service:
+When matching ports are not specified,
+the UDP route will match all the ports of a Kubernetes service:
 
 ```yaml
 kind: UDPRoute


### PR DESCRIPTION
Changes:

* Add `matches.ports` field to TCPRoute spec
* Add UDPRoute spec
* Replace TrafficTarget `destination.port` with TCP/UDPRoute `matches.ports` (**breaking change**)

These changes make the TrafficTarget less verbose when a service exposes multiple ports, a single TrafficTarget can match multiple protocols and ports. TrafficTarget was extended in order to support UDP traffic.

Ref: #108 #156 #150 #151