### PR TITLE
fix percentages mentioned in description for TrafficSplit

### DIFF
--- a/apis/traffic-split/traffic-split-WD.md
+++ b/apis/traffic-split/traffic-split-WD.md
@@ -55,8 +55,8 @@ spec:
     weight: 10
 ```
 
-The above configuration will route 10% of the `website` incoming
-traffic to the `website-v1` service and 90% to `website-v2` service.
+The above configuration will route 90% of the `website` incoming
+traffic to the `website-v1` service and 10% to `website-v2` service.
 
 A/B test example:
 


### PR DESCRIPTION
According to the weight specified in the `TrafficSplit` sample, the description below the sample was wrong.


Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>