### PR TITLE
fix wrong service name mentioned in example

### DIFF
--- a/apis/traffic-split/traffic-split-WD.md
+++ b/apis/traffic-split/traffic-split-WD.md
@@ -386,4 +386,4 @@ upstream backend {
 ```
 
 Thus the new `web` service when accessed from a client in Kubernetes will send
-10% of it's traffic to `web-next` and 90% of it's traffic to `web`.
+10% of it's traffic to `web-next` and 90% of it's traffic to `web-current`.


### PR DESCRIPTION
The `TrafficSplit` sample balanced incoming traffic between `web-next` and `web-current`. However, the description mentioned `web` as target instead of `web-current`

Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>