### PR TITLE
Rename maesh to traefik mesh in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following documents are available:
 * **Flagger:** progressive delivery operator ([flagger.app](https://flagger.app))
 * **Istio\*:** connect, secure, control, observe ([servicemeshinterface/smi-adapter-istio](https://github.com/servicemeshinterface/smi-adapter-istio))
 * **Linkerd:** ultralight service mesh ([linkerd.io](https://linkerd.io))
-* **Maesh:** simpler service mesh ([mae.sh](https://mae.sh))
+* **Traefik Mesh:** simpler service mesh ([traefik.io/traefik-mesh](https://traefik.io/traefik-mesh))
 * **Meshery:** the service mesh management plane ([layer5.io/meshery](https://layer5.io/meshery))
 * **Rio:** application deployment engine ([rio.io](https://rio.io))
 * **Service Mesh Hub:** unified dashboard ([solo.io/products/service-mesh-hub](https://solo.io/products/service-mesh-hub))


### PR DESCRIPTION
👋 Hello

As you probably know `Maesh` has been renamed to `Traefik Mesh` recently. According to this, I've updated the ecosystem section in the readme to reflect the change.