### PR TITLE
Add Michael Hausenblas as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout @ilevine
+* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout @ilevine @mhausenblas


### PR DESCRIPTION
Signed-off-by: Michelle Noorali <michellemolu@gmail.com>

The current maintainers of SMI would like to invite @mhausenblas to be a maintainer on the SMI project. A vote was conducted and super majority was reached. 🎉 @mhausenblas - We really appreciate your involvement and perspective in the SMI community and think you'd make a great addition to the team if you so choose.