### PR TITLE
Add Tarun Pothulapati as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout @ilevine @mhausenblas
+* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout @ilevine @mhausenblas @pothulapati


### PR DESCRIPTION
Signed-off-by: Michelle Noorali <michellemolu@gmail.com>

The current maintainers of SMI would like to invite @Pothulapati to be a maintainer on the SMI project. A vote was conducted and super majority was reached. 🎉 @Pothulapati - We really appreciate your contribution to SMI Metrics and your involvement in the SMI community and think you'd make a great addition to the team if you so choose.

