### PR TITLE
Clarify: scope includes but is not limited to k8s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 
 ## Service Mesh Interface
 
-The Service Mesh Interface (SMI) is a specification for service meshes that run
-on Kubernetes. It defines a common standard that can be implemented by a variety
-of providers. This allows for both standardization for end-users and innovation
-by providers of Service Mesh Technology. SMI enables flexibility and
-interoperability, and covers the most common service mesh capabilities.
+The Service Mesh Interface (SMI) is a specification for service meshes, with a
+focus on those that run on Kubernetes. It defines a common standard that can be
+implemented by a variety of providers. This allows for both standardization for
+end-users and innovation by providers of Service Mesh Technology. SMI enables
+flexibility and interoperability, and covers the most common service mesh
+capabilities.
 
 ### Service Mesh Interface Documents
 


### PR DESCRIPTION
Based on the discussion in today's SMI working group for multi-cluster, we want to clarify that SMI includes but is not limited to Kubernetes.

This changes "a specification for service meshes that run on Kubernetes" to "a specification for service meshes, with a
focus on those that run on Kubernetes".

If we can have maintainers indicate their approval of (or changes to) this PR, that will serve to indicate consensus.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>