### PR TITLE
Meetings are back to alternate Wednesdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following documents are available:
 
 ### Community Meeting
 
-* Community Meeting: every Wednesday at 10:00-10:30 Pacific: [https://zoom.us/my/cncfsmiproject](https://zoom.us/my/cncfsmiproject)
+* Community Meeting: every other Wednesday at 10:00-10:30 Pacific: [https://zoom.us/my/cncfsmiproject](https://zoom.us/my/cncfsmiproject)
   * [Calendar invite](https://calendar.google.com/calendar/embed?src=v2ailcfbvg9mgco5p0ms4t8ou8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
   * [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
   * [CNCF YouTube Playlist for SMI community meetings](https://www.youtube.com/playlist?list=PLL6_4qADP2SpZ_dWUY0okz5zOgrs_HAqg)


### PR DESCRIPTION
We aren't regularly running the working group meetings, so the community call is just on alternate Wednesdays.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>