### PR TITLE
Updating spec maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @bridgetkromhout @ilevine @mhausenblas @pothulapati
+* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @bridgetkromhout @ilevine @mhausenblas @pothulapati @keithmattix @jbyers19


### PR DESCRIPTION
Per the [SMI Spec Governance guidelines](https://github.com/servicemeshinterface/smi-spec/blob/main/GOVERNANCE.md#project-maintainers), we have voted in two new spec maintainers. Welcome, @keithmattix and @jbyers19! 

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>