### PR TITLE
SMI meeting hiatus for GAMMA launch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ The following documents are available:
 
 ### Community Meeting
 
-* Community Meeting: every other Wednesday at 10:00-10:30 Pacific: [https://zoom.us/my/cncfsmiproject](https://zoom.us/my/cncfsmiproject)
-  * [Calendar invite](https://calendar.google.com/calendar/embed?src=v2ailcfbvg9mgco5p0ms4t8ou8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+* SMI community meetings are on hiatus until October 12, 2022 to allow for focus on the [GAMMA initiative](https://smi-spec.io/blog/announcing-smi-gateway-api-gamma/).
   * [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
   * [CNCF YouTube Playlist for SMI community meetings](https://www.youtube.com/playlist?list=PLL6_4qADP2SpZ_dWUY0okz5zOgrs_HAqg)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The following documents are available:
 
 ### Community Meeting
 
-* SMI community meetings are on hiatus until October 12, 2022 to allow for focus on the [GAMMA initiative](https://smi-spec.io/blog/announcing-smi-gateway-api-gamma/).
+* SMI community meetings are on hiatus until October 12, 2022 to allow for
+focus on the [GAMMA initiative](https://smi-spec.io/blog/announcing-smi-gateway-api-gamma/).
   * [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
   * [CNCF YouTube Playlist for SMI community meetings](https://www.youtube.com/playlist?list=PLL6_4qADP2SpZ_dWUY0okz5zOgrs_HAqg)
 


### PR DESCRIPTION
As discussed on Slack, SMI community meetings are on hiatus until October 12th to allow time for maintainers and community members to focus on the GAMMA launch.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>